### PR TITLE
Remove pending order expiration

### DIFF
--- a/Gap-and-Go A.cs
+++ b/Gap-and-Go A.cs
@@ -897,11 +897,7 @@ namespace cAlgo.Robots
                     Print($"Processing 4th bar rules for order {patternOrder.OrderId}");
                     ProcessFourthBarRules(patternOrder, pendingOrder, currentBar, ordersToRemove);
                 }
-                else if ((Server.Time - patternOrder.TimeCreated).TotalHours > 12)
-                {
-                    Print($"Order {patternOrder.OrderId} expired (>12 hours) - removing");
-                    ordersToRemove.Add(patternOrder);
-                }
+                // Removed expiration check to allow orders to remain pending beyond 12 hours
             }
             
             ordersToRemove.ForEach(order => _pendingPatternOrders.Remove(order));


### PR DESCRIPTION
## Summary
- remove 12-hour expiration condition from `CheckPendingPatternOrders`

## Testing
- `mcs "Gap-and-Go A.cs" -out:GapAndGo.dll` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415a42f7a0832caa634143a6d722d6