### PR TITLE
Add cTrader trading history table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Buddy Style Web Demo
 
-This project is a small static website inspired by Buddy.ai. It includes a hero section, feature highlights, and a simple contact form.
+This project is a small static website inspired by Buddy.ai. It includes a hero section, feature highlights, a basic integration with the cTrader Open API, and a simple contact form.
 
 ## Files
 
-- `index.html` – main page with features, how it works, and contact sections.
-- `styles.css` – styling for layout and interactive elements.
-- `script.js` – handles form submission and smooth scrolling.
+- `index.html` – main page with features, how it works, a trading history table, and contact sections.
+- `styles.css` – styling for layout, the trading history table, and interactive elements.
+- `script.js` – handles form submission, smooth scrolling, and cTrader API calls.
 
 Open `index.html` in your browser to view the site.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
             <ul>
                 <li><a href="#features">Features</a></li>
                 <li><a href="#how-it-works">How it Works</a></li>
+                <li><a href="#trading-history">Trading History</a></li>
                 <li><a href="#contact">Contact</a></li>
             </ul>
         </nav>
@@ -49,6 +50,24 @@
             <li>Follow the friendly voice instructions in each lesson.</li>
             <li>Track progress and celebrate achievements together.</li>
         </ol>
+    </section>
+
+    <section id="trading-history">
+        <h2>Trading History</h2>
+        <p>View the latest closed trades from your cTrader account.</p>
+        <table id="history-table">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>Symbol</th>
+                    <th>Volume</th>
+                    <th>Profit</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td colspan="4">Loading...</td></tr>
+            </tbody>
+        </table>
     </section>
 
     <section id="contact">

--- a/script.js
+++ b/script.js
@@ -14,3 +14,34 @@ document.querySelectorAll('a[href^="#"]').forEach(link => {
         }
     });
 });
+
+// Fetch trading history from cTrader Open API
+async function loadHistory() {
+    // Replace with your real access token and account ID
+    const token = '';
+    const accountId = '';
+    if (!token || !accountId) {
+        console.warn('cTrader credentials missing');
+        return;
+    }
+    const tbody = document.querySelector('#history-table tbody');
+    try {
+        const res = await fetch(`https://openapi.spotware.com/connect/trading-accounts/${accountId}/history`, {
+            headers: {
+                'Authorization': `Bearer ${token}`
+            }
+        });
+        const data = await res.json();
+        tbody.innerHTML = '';
+        (data.trades || data).forEach(trade => {
+            const row = document.createElement('tr');
+            row.innerHTML = `<td>${trade.closeTime}</td><td>${trade.symbolName}</td><td>${trade.volume}</td><td>${trade.profit}</td>`;
+            tbody.appendChild(row);
+        });
+    } catch (err) {
+        console.error(err);
+        tbody.innerHTML = '<tr><td colspan="4">Failed to load history</td></tr>';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadHistory);

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,17 @@ button {
     padding: 0.5rem;
 }
 
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    text-align: left;
+}
+
 footer {
     background-color: #f1f1f1;
     text-align: center;


### PR DESCRIPTION
## Summary
- integrate cTrader Open API call placeholder
- display trading history table on page
- basic table styles
- mention new feature in README

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685835e8f03c832c950ab63d0a3605cc